### PR TITLE
aws-vpn-client

### DIFF
--- a/nix/base/modules/airplay-server.nix
+++ b/nix/base/modules/airplay-server.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, nix-vscode-extensions, ... }:
+{ pkgs, ... }:
 
 {
   environment.systemPackages = with pkgs; [ uxplay ];

--- a/nix/base/modules/ausweis-app.nix
+++ b/nix/base/modules/ausweis-app.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, nix-vscode-extensions, ... }:
+{ pkgs, ... }:
 
 {
   environment.systemPackages = with pkgs; [ ausweisapp ];

--- a/nix/base/modules/nocodb.nix
+++ b/nix/base/modules/nocodb.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, lib, nix-vscode-extensions, ... }:
-
 {
   # TODO run container in rootless mode
   virtualisation.oci-containers.containers."noco" = {

--- a/nix/base/modules/quick-share.nix
+++ b/nix/base/modules/quick-share.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, nix-vscode-extensions, ... }:
+{ pkgs, ... }:
 
 {
   environment.systemPackages = with pkgs; [ rquickshare ];

--- a/nix/base/modules/shell/fish-shell.nix
+++ b/nix/base/modules/shell/fish-shell.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, nix-vscode-extensions, ... }:
+{ pkgs, lib, ... }:
 
 {
 
@@ -30,7 +30,7 @@
     programs.oh-my-posh = {
       enable = true;
       enableFishIntegration = true;
-      settings = builtins.fromJSON (builtins.unsafeDiscardStringContext (builtins.readFile "/etc/dotfiles/nix/base/modules/shell/oh-my-posh-config.json"));
+      settings = builtins.fromJSON (builtins.unsafeDiscardStringContext (builtins.readFile ./oh-my-posh-config.json));
     };
 
     programs.atuin = {

--- a/nix/base/modules/shell/fish-shell.nix
+++ b/nix/base/modules/shell/fish-shell.nix
@@ -37,6 +37,10 @@
       enable = true;
       enableFishIntegration = true;
     };
+    home.file.".config/atuin/config.toml".text = ''
+      filter_mode = "workspace"
+      workspaces = true
+    '';
   });
 
   users.defaultUserShell = pkgs.fish;

--- a/nix/base/profiles/personal-config.nix
+++ b/nix/base/profiles/personal-config.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, pkgs-unstable, nix-vscode-extensions, ... }:
+{ pkgs, pkgs-unstable, inputs, ... }:
 
 {
   imports = [
@@ -28,14 +28,14 @@
     # VS Code
     (vscode-with-extensions.override {
       vscodeExtensions = let
-        vscode-extensions = nix-vscode-extensions.extensions.${pkgs.stdenv.hostPlatform.system};
+        vscode-extensions = inputs.nix-vscode-extensions.extensions.${pkgs.stdenv.hostPlatform.system};
       in
-        with pkgs.lib.foldl' (acc: set: pkgs.lib.recursiveUpdate acc set) {} [
-          vscode-extensions.vscode-marketplace
-          vscode-extensions.open-vsx
-          vscode-extensions.vscode-marketplace-release
-          vscode-extensions.open-vsx-release
-        ];
+        with pkgs.lib.foldl' (acc: set: pkgs.lib.recursiveUpdate acc set) {} (with vscode-extensions; [
+          vscode-marketplace
+          open-vsx
+          vscode-marketplace-release
+          open-vsx-release
+        ]);
       [
         # general
         k--kato.intellij-idea-keybindings

--- a/nix/base/profiles/personal-config.nix
+++ b/nix/base/profiles/personal-config.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgs-unstable, inputs, ... }:
+{ pkgs, inputs, ... }:
 
 {
   imports = [
@@ -9,6 +9,8 @@
     ../modules/nocodb.nix
     ../modules/quick-share.nix
   ];
+
+  nixpkgs.overlays = [inputs.self.overlays.default];
 
   #################################
   ############ PACKAGES ###########
@@ -23,7 +25,7 @@
 
     # Jetbrains
     jetbrains.idea-ultimate
-    pkgs-unstable.jetbrains.webstorm
+    unstable.jetbrains.webstorm
 
     # VS Code
     (vscode-with-extensions.override {

--- a/nix/base/profiles/work-config.nix
+++ b/nix/base/profiles/work-config.nix
@@ -19,6 +19,8 @@
     # Jetbrains
     jetbrains.idea-ultimate
 
+    aws-vpn-client
+
     # VS Code
     (vscode-with-extensions.override {
       # TODO remove after unstable updated to 1.93.0

--- a/nix/base/profiles/work-config.nix
+++ b/nix/base/profiles/work-config.nix
@@ -7,6 +7,8 @@
     ../modules/nocodb.nix
   ];
 
+  nixpkgs.overlays = [inputs.self.overlays.default];
+
   #################################
   ############ PACKAGES ###########
   #################################

--- a/nix/base/profiles/work-config.nix
+++ b/nix/base/profiles/work-config.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, nix-vscode-extensions, ... }:
+{ pkgs, lib, inputs, ... }:
 
 {
   imports = [
@@ -31,7 +31,7 @@
       });
 
       vscodeExtensions = let
-        vscode-extensions = nix-vscode-extensions.extensions.${pkgs.stdenv.hostPlatform.system};
+        vscode-extensions = inputs.nix-vscode-extensions.extensions.${pkgs.stdenv.hostPlatform.system};
       in
         with pkgs.lib.foldl' (acc: set: pkgs.lib.recursiveUpdate acc set) {} [
           vscode-extensions.vscode-marketplace

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "aws-vpn-client": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-mozilla": "nixpkgs-mozilla"
+      },
+      "locked": {
+        "lastModified": 1733004669,
+        "narHash": "sha256-T281JyXFxBLbWeMmqHBEM2IVHXbZzQvO/YWUqpeZ6R8=",
+        "owner": "JonathanxD",
+        "repo": "openaws-vpn-client",
+        "rev": "ece1a631326a224ad471deffd8e42cbe7293eb57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JonathanxD",
+        "repo": "openaws-vpn-client",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -19,6 +42,24 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -55,6 +96,24 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1698420672,
+        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nix-ld": {
       "inputs": {
         "nixpkgs": [
@@ -78,8 +137,8 @@
     "nix-vscode-extensions": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1733882180,
@@ -97,17 +156,31 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713805509,
-        "narHash": "sha256-YgSEan4CcrjivCNO5ZNzhg7/8ViLkZ4CB/GrGBVSudo=",
+        "lastModified": 1702900294,
+        "narHash": "sha256-pt7sSoJYNw3n8YtXw0Z/Nnr6/PfY2YrjDvqboErXnRM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
+        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-mozilla": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1704373101,
+        "narHash": "sha256-+gi59LRWRQmwROrmE1E2b3mtocwueCQqZ60CwLG+gbg=",
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "9b11a87c0cc54e308fa83aac5b4ee1816d5418a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
         "type": "github"
       }
     },
@@ -129,6 +202,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1713805509,
+        "narHash": "sha256-YgSEan4CcrjivCNO5ZNzhg7/8ViLkZ4CB/GrGBVSudo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1733808091,
         "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "nixos",
@@ -145,14 +234,30 @@
     },
     "root": {
       "inputs": {
+        "aws-vpn-client": "aws-vpn-client",
         "home-manager": "home-manager",
         "nix-ld": "nix-ld",
         "nix-vscode-extensions": "nix-vscode-extensions",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -5,7 +5,7 @@
         "flake-utils": "flake-utils",
         "naersk": "naersk",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-aws-vpn-client"
         ],
         "nixpkgs-mozilla": "nixpkgs-mozilla"
       },
@@ -168,6 +168,22 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-aws-vpn-client": {
+      "locked": {
+        "lastModified": 1702900294,
+        "narHash": "sha256-pt7sSoJYNw3n8YtXw0Z/Nnr6/PfY2YrjDvqboErXnRM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "886c9aee6ca9324e127f9c2c4e6f68c2641c8256",
+        "type": "github"
+      }
+    },
     "nixpkgs-mozilla": {
       "flake": false,
       "locked": {
@@ -239,6 +255,7 @@
         "nix-ld": "nix-ld",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-aws-vpn-client": "nixpkgs-aws-vpn-client",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -11,6 +11,10 @@
       url = "github:Mic92/nix-ld";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    aws-vpn-client = {
+      url = "github:JonathanxD/openaws-vpn-client";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs: {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -13,22 +13,21 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, nix-vscode-extensions, nix-ld }: {
-    nixosConfigurations = builtins.mapAttrs (device: value: nixpkgs.lib.nixosSystem {
-      system = value.system;
+  outputs = inputs: {
+    nixosConfigurations = builtins.mapAttrs (device: value: inputs.nixpkgs.lib.nixosSystem {
+      inherit (value) system;
       specialArgs = {
-        inherit nix-vscode-extensions;
-        device = device;
-        pkgs-unstable = import nixpkgs-unstable {
-          system = value.system;
+        inherit inputs device;
+        pkgs-unstable = import inputs.nixpkgs-unstable {
+          inherit (value) system;
           config.allowUnfree = true;
         };
       };
       modules = [
         ./base/minimum.nix
         ./devices/${device}/default.nix
-        nix-ld.nixosModules.nix-ld
-        home-manager.nixosModules.home-manager
+        inputs.nix-ld.nixosModules.nix-ld
+        inputs.home-manager.nixosModules.home-manager
       ];
     }) {
       personal-desktop = { system = "x86_64-linux"; };

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -18,14 +18,10 @@
       inherit (value) system;
       specialArgs = {
         inherit inputs device;
-        pkgs-unstable = import inputs.nixpkgs-unstable {
-          inherit (value) system;
-          config.allowUnfree = true;
-        };
       };
       modules = [
         ./base/minimum.nix
-        ./devices/${device}/default.nix
+        ./devices/${device}
         inputs.nix-ld.nixosModules.nix-ld
         inputs.home-manager.nixosModules.home-manager
       ];
@@ -34,5 +30,6 @@
       personal-laptop = { system = "x86_64-linux"; };
       work-laptop = { system = "x86_64-linux"; };
     };
+    overlays = import ./overlays.nix inputs;
   };
 }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -11,9 +11,11 @@
       url = "github:Mic92/nix-ld";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    nixpkgs-aws-vpn-client.url = "github:nixos/nixpkgs?rev=886c9aee6ca9324e127f9c2c4e6f68c2641c8256";
     aws-vpn-client = {
       url = "github:JonathanxD/openaws-vpn-client";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "nixpkgs-aws-vpn-client";
     };
   };
 

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -6,7 +6,13 @@ inputs: rec {
         };
     };
 
+    # TODO remove after project uses flakes correctly
+    aws-vpn-client = final: prev: {
+        aws-vpn-client = inputs.aws-vpn-client.defaultPackage.${prev.system};
+    };
+
     default = inputs.nixpkgs.lib.composeManyExtensions [
         all-channels
+        aws-vpn-client
     ];
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,12 @@
+inputs: rec {
+    all-channels = final: prev: {
+        unstable = import inputs.nixpkgs-unstable {
+            inherit (prev) system;
+            config.allowUnfree = true;
+        };
+    };
+
+    default = inputs.nixpkgs.lib.composeManyExtensions [
+        all-channels
+    ];
+}


### PR DESCRIPTION
To add `aws-vpn-client`, I first refactored `inputs` handling by passing them as `specialArgs` within each file, avoiding unnecessary clutter in specialArgs.

Additionally, I moved the `unstable` package channel into an overlay, allowing it to be used like this:

```nix
environment.systemPackages = [pkgs.unstable.packageName];
```

>[!NOTE]
> Overlays are currently enabled in both the personal and work configurations. I recommend creating a common configuration for settings that should be applied universally across all devices.

I also had to define a custom overlay for `aws-vpn-client` because the project does not follow the standard flake output structure.

Lastly, I fixed an issue where the dotfiles would fail to build if not located in `/etc/dotfiles`. This was addressed by changing the file path reference from:

```nix
builtins.readFile "/etc/dotfiles/nix/base/modules/shell/oh-my-posh-config.json"
```

to a relative path:
```nix
builtins.readFile ./oh-my-posh-config.json
```

